### PR TITLE
Better cli help

### DIFF
--- a/src/github.com/abrie/censusgeocoder/cmd/cli/commands/benchmarks.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/commands/benchmarks.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 )
@@ -20,4 +21,9 @@ func GetBenchmarks(args []string) {
 	utils.PrettyPrint(result)
 
 	os.Exit(0)
+}
+
+func HelpBenchmarks() {
+	fmt.Printf("usage: censusgeocoder benchmarks\n\n")
+	fmt.Printf("Lists all available benchmarks. A benchmark is a numerical ID or\nname that references what version of the locator should be searched. This\ngenerally corresponds to MTDB data which is benchmarked twice yearly. A full list\nof options can be accessed at https://geocoding.geo.census.gov/geocoder/benchmarks.\nThe general format of the name is DatasetType_SpatialBenchmark.")
 }

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/commands/geographies.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/commands/geographies.go
@@ -72,6 +72,10 @@ func SearchGeographies(args []string) {
 
 }
 
+func HelpGeographies() {
+	fmt.Printf("usage: geographies [-oneline] [-street -city -state] [-benchmark] [-vintage]\n")
+}
+
 func searchOneLineAddressGeographies(oneline, benchmark, vintage *string, layers []string) {
 	result, err := censusgeocoder.SearchOneLineAddressGeographies(context.Background(), *oneline, *benchmark, *vintage, layers)
 	if err != nil {

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/commands/help.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/commands/help.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetHelp(args []string) {
+	if len(args) == 0 {
+		HelpHelp()
+	}
+
+	switch args[0] {
+	case "benchmarks":
+		HelpBenchmarks()
+	case "vintages":
+		HelpVintages()
+	case "locations":
+		HelpLocations()
+	case "geographies":
+		HelpGeographies()
+	}
+}
+
+func HelpHelp() {
+	fmt.Printf("usage: help <command>\n")
+	os.Exit(2)
+}

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/commands/locations.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/commands/locations.go
@@ -55,6 +55,10 @@ func SearchLocations(args []string) {
 	os.Exit(2)
 }
 
+func HelpLocations() {
+	fmt.Printf("usage: locations [-oneline] [-street -city -state] [-benchmark]\n")
+}
+
 func searchOneLineAddressLocations(oneline, benchmark *string) {
 	result, err := censusgeocoder.SearchOneLineAddressLocations(context.Background(), *oneline, *benchmark)
 	if err != nil {

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/commands/vintages.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/commands/vintages.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 )
@@ -33,5 +34,11 @@ func GetVintages(args []string) {
 
 	utils.PrettyPrint(result)
 
+	os.Exit(0)
+}
+
+func HelpVintages() {
+	fmt.Printf("usage: censusgeocoder vintages <benchmark>\n\n")
+	fmt.Printf("Lists all vintages available for a benchmark. This parameter is\nused when doing geographies lookups. For a web interface with more information,\nrefer to the official web page: https://geocoding.geo.census.gov/geocoder/vintages.\n\n")
 	os.Exit(0)
 }

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/main.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/main.go
@@ -11,7 +11,10 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Printf("Need parameters...\n")
+		fmt.Printf("This is an unoffical cli interface to the Census.gov Geocoder.\n")
+		fmt.Printf("See https://geocoding.geo.census.gov/ for the service it interacts with.\n\n")
+		fmt.Printf("Usage:\n\n\tcensusgeocoder <command> [parameters]\n\n")
+		fmt.Printf("The commands are:\n\n\tbenchmarks\n\tvintages\n\tlocation\n\tgeographies\n\n")
 		os.Exit(1)
 	}
 

--- a/src/github.com/abrie/censusgeocoder/cmd/cli/main.go
+++ b/src/github.com/abrie/censusgeocoder/cmd/cli/main.go
@@ -30,6 +30,8 @@ func main() {
 		commands.SearchLocations(args)
 	case "geographies":
 		commands.SearchGeographies(args)
+	case "help":
+		commands.GetHelp(args)
 	default:
 		fmt.Printf("Unknown command.\n")
 		os.Exit(2)


### PR DESCRIPTION
This PR adds help text for each command. The help text describes how to invoke the command by listing required parameters and (in the case of benchmarks and vintages) a brief description.